### PR TITLE
Remove default version for plugin builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ def pluginVersion
 if (versionDetails().lastTag ==~ /^v\d+\.\d+\.\d+$/) {
     pluginVersion = versionDetails().lastTag[1..-1]
 } else {
-    pluginVersion = "0.0.1";
+    pluginVersion = null;
 }
 version pluginVersion
 


### PR DESCRIPTION
Closes https://github.com/SyneRBI/xnat-interfile/issues/8

After making a release on `main`, removing the default version seems to cause no issues.