### PR TITLE
Add remaining tests

### DIFF
--- a/python/src/xnat_interfile/interfile_2_xnat.py
+++ b/python/src/xnat_interfile/interfile_2_xnat.py
@@ -44,7 +44,7 @@ def interfile_listmode_2_xnat(
         float(interfile_listmode_header.get_exam_info().get_high_energy_thres())
     )
     pat_pos = str(interfile_listmode_header.get_exam_info().patient_position)
-    pat_pos = pat_pos.replace("<interfile::PatientPosition::", "").replace(">", "")
+    pat_pos = pat_pos.replace("<stir::PatientPosition::", "").replace(">", "")
     xnat_interfile_dict["interfile:petLmScanData/examInformation/patientPosition"] = (
         pat_pos
     )

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -111,7 +111,7 @@ def test_upload_of_data(xnat_connection, interfile_file_path):
 
     add_project(xnat_session, project_name)
 
-    scan_name = upload_interfile_data(
+    upload_interfile_data(
         xnat_session,
         interfile_file_path,
         project_name,
@@ -137,3 +137,31 @@ def test_upload_of_data(xnat_connection, interfile_file_path):
     ]
 
     verify_headers_match(interfile_file_path, xnat_experiment.scans[0])
+
+
+@pytest.mark.usefixtures("remove_test_data")
+def test_interfile_data_modification(xnat_connection, interfile_file_path):
+    xnat_session = xnat_connection.session
+    project_id = "interfile_project"
+    add_project(xnat_session, project_id)
+
+    upload_interfile_data(
+        xnat_session,
+        interfile_file_path,
+        project_id,
+        "interfile_subject",
+        "interfile_experiment",
+        "interfile_scan",
+    )
+    subject = xnat_session.projects[project_id].subjects[0]
+
+    xnat_header = "radionuclideInformation/energy"
+    all_headers = subject.experiments[0].scans[0].data
+    assert all_headers[xnat_header] == 511
+    all_headers[xnat_header] = 513
+    assert all_headers[xnat_header] == 513
+    assert xnat_header in all_headers.keys()
+    new_header = "energy"
+    all_headers[new_header] = all_headers.pop(xnat_header)
+    assert new_header in all_headers.keys()
+    assert xnat_header not in all_headers.keys()

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -165,3 +165,24 @@ def test_interfile_data_modification(xnat_connection, interfile_file_path):
     all_headers[new_header] = all_headers.pop(xnat_header)
     assert new_header in all_headers.keys()
     assert xnat_header not in all_headers.keys()
+
+
+@pytest.mark.usefixtures("remove_test_data")
+def test_interfile_data_deletion(xnat_connection, interfile_file_path):
+    xnat_session = xnat_connection.session
+    project_id = "interfile_project"
+    add_project(xnat_session, project_id)
+
+    upload_interfile_data(
+        xnat_session,
+        interfile_file_path,
+        project_id,
+        "interfile_subject",
+        "interfile_experiment",
+        "interfile_scan",
+    )
+
+    experiments = xnat_session.projects[project_id].subjects[0].experiments
+    assert len(experiments) == 1
+    experiments[0].delete()
+    assert len(experiments) == 0


### PR DESCRIPTION
Add tests for:
- modifying interfile metadata
- deleting data
- updating the plugin

I had to make one minor change to `interfile_2_xnat.py` to get the header verification to work. `<stir::PatientPosition::HFS>` is the header in the file, so the old processing resulted in: `<stir::PatientPosition::HFS` being uploaded to xnat. The special `<` character was causing it to not match the uploaded header.

